### PR TITLE
Fix crowding distance attribution in archive truncation

### DIFF
--- a/src/patatune/mopso/mopso.py
+++ b/src/patatune/mopso/mopso.py
@@ -347,27 +347,25 @@ class MOPSO(Optimizer):
             (dict): A dictionary mapping each particle in the Pareto front to its crowding distance.
         """
         if len(pareto_front) == 0:
-            return []
+            return {}
         num_objectives = len(np.ravel(pareto_front[0].fitness))
-        distances = [0] * len(pareto_front)
-        point_to_distance = {}
+        # Distances are keyed by particle, not by position in the list
+        distances = {particle: 0.0 for particle in pareto_front}
         for i in range(num_objectives):
             # Sort by objective i
             sorted_front = sorted(
                 pareto_front, key=lambda x: np.ravel(x.fitness)[i])
             # Set the boundary points to infinity
-            distances[0] = float('inf')
-            distances[-1] = float('inf')
+            distances[sorted_front[0]] = float('inf')
+            distances[sorted_front[-1]] = float('inf')
             # Normalize the objective values for calculation
             min_obj = np.ravel(sorted_front[0].fitness)[i]
             max_obj = np.ravel(sorted_front[-1].fitness)[i]
             norm_denom = max_obj - min_obj if max_obj != min_obj else 1
             for j in range(1, len(pareto_front) - 1):
-                distances[j] += (np.ravel(sorted_front[j + 1].fitness)[i] -
-                                 np.ravel(sorted_front[j - 1].fitness)[i]) / norm_denom
-        for i, point in enumerate(pareto_front):
-            point_to_distance[point] = distances[i]
-        return point_to_distance
+                distances[sorted_front[j]] += (np.ravel(sorted_front[j + 1].fitness)[i] -
+                                               np.ravel(sorted_front[j - 1].fitness)[i]) / norm_denom
+        return distances
 
     def scatter_particle(self, particle: Particle):
         """Scatters a particle that has not improved for a certain number of iterations.


### PR DESCRIPTION
`calculate_crowding_distance` sorts the front per objective but stores each distance by its position in the sorted list, and finally maps them back to particles by their position in the original list. Since sorting permutes the front, distances get attributed to the wrong particles, including the boundary infinities that should protect the extremes; archive truncation can then drop the extreme points of the front.

On ZDT1 (100 particles, archive cap 200, 600 iterations), this makes the archive decay during the run - the final hypervolume ends up 27.5% below the level it had already reached earlier in the same run. With the fix the loss is 0.0%.

The fix keys the distances by the particles themselves, which makes the result independent of the input order and removes the need for the final remapping loop. The empty-front return becomes `{}` to match the documented return type. Structure is otherwise unchanged.